### PR TITLE
Moved User struct to model folder

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1,55 +1,11 @@
 use sqlx::postgres::{PgPool, PgPoolOptions};
-use sqlx::{
-    FromRow,
-    Executor,
-    Postgres,
-    migrate,
-    query_as,
-    query_scalar,
-};
-use std::fmt::{Display, Formatter};
+use sqlx::{migrate};
 use anyhow::{Result, Context};
-use serde::{Deserialize, Serialize};
 use crate::settings::SETTINGS;
 use tracing::info;
 
 pub struct DB {
   pool: PgPool
-}
-
-#[derive(FromRow, Debug, Serialize, Deserialize)]
-pub struct User {
-  pub id: Option<i64>,
-  pub name: String,
-  pub email: String
-}
-
-impl Display for User {
-  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-    match self.id {
-      Some(i) => write!(f, "id: {}, name: {}, email: {}", i, self.name, self.email),
-      None => write!(f, "id: None, name: {}, email: {}", self.name, self.email),
-    }
-  }
-}
-
-impl User {
-  pub async fn all<'a, E>(ex: E) -> Result<Vec<User>>
-  where E: 'a + Executor<'a, Database = Postgres>
-  {
-    let users = query_as::<_, User>("select * from users").fetch_all(ex).await?;
-    Ok(users)
-  }
-
-  pub async fn insert<'a,  E>(&mut self, ex: E) -> Result<()>
-  where E: 'a + Executor<'a, Database = Postgres>
-  {
-    let id = query_scalar::<_, i64>("insert into users(name, email) values($1, $2) returning id")
-    .bind(self.name.clone()).bind(self.email.clone())
-    .fetch_one(ex).await.context("Unable to save")?;
-    self.id = Some(id);
-    Ok(())
-  }
 }
 
 impl DB {
@@ -74,7 +30,8 @@ impl DB {
 #[cfg(test)]
 mod tests {
   use sqlx::Acquire;
-  use super::{DB, User};
+  use super::DB;
+  use crate::model::User;
   #[tokio::test]
   async fn test_should_connect() {
     let db = DB::new().await.unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod db;
+pub mod model;
 pub mod router;
 pub mod server;
 pub mod settings;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod user;
+
+pub use user::User;

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -1,0 +1,45 @@
+use sqlx::{
+    FromRow,
+    Executor,
+    Postgres,
+    query_as,
+    query_scalar,
+};
+use std::fmt::{Display, Formatter};
+use serde::{Deserialize, Serialize};
+use anyhow::{Result, Context};
+
+#[derive(FromRow, Debug, Serialize, Deserialize)]
+pub struct User {
+  pub id: Option<i64>,
+  pub name: String,
+  pub email: String
+}
+
+impl Display for User {
+  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    match self.id {
+      Some(i) => write!(f, "id: {}, name: {}, email: {}", i, self.name, self.email),
+      None => write!(f, "id: None, name: {}, email: {}", self.name, self.email),
+    }
+  }
+}
+
+impl User {
+  pub async fn all<'a, E>(ex: E) -> Result<Vec<User>>
+  where E: 'a + Executor<'a, Database = Postgres>
+  {
+    let users = query_as::<_, User>("select * from users").fetch_all(ex).await?;
+    Ok(users)
+  }
+
+  pub async fn insert<'a,  E>(&mut self, ex: E) -> Result<()>
+  where E: 'a + Executor<'a, Database = Postgres>
+  {
+    let id = query_scalar::<_, i64>("insert into users(name, email) values($1, $2) returning id")
+    .bind(self.name.clone()).bind(self.email.clone())
+    .fetch_one(ex).await.context("Unable to save")?;
+    self.id = Some(id);
+    Ok(())
+  }
+}

--- a/src/router.rs
+++ b/src/router.rs
@@ -11,7 +11,7 @@ use axum::{
 use tower::ServiceBuilder;
 use tower_http::trace::TraceLayer;
 
-use crate::{app_state::{AppState}, db::User};
+use crate::{app_state::{AppState}, model::User};
 
 async fn home_handler() -> String {
     String::from("Hello server\n")

--- a/tests/muservice.rs
+++ b/tests/muservice.rs
@@ -1,6 +1,6 @@
 use axum::{body::Body, http::Request};
 use http::StatusCode;
-use libmuservice::{app_state::AppState, db::{DB, User}};
+use libmuservice::{app_state::AppState, db::DB, model::User};
 use sqlx::PgPool;
 use tower::{ServiceExt, Service};
 use std::net::{SocketAddr, TcpListener};


### PR DESCRIPTION
Closes #7. Creates a model folder where any DB structs would be placed, offering users one example of a project layout.