### PR TITLE
color-eyre (no span traces)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,12 +36,6 @@ checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "anyhow"
-version = "1.0.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508b352bb5c066aac251f6daf6b36eccd03e8a88e8081cd44959ea277a3af9a8"
 
 [[package]]
 name = "async-trait"
@@ -100,6 +109,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +173,33 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "color-eyre"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
 
 [[package]]
 name = "config"
@@ -282,6 +333,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,6 +430,12 @@ dependencies = [
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
 name = "hashbrown"
@@ -511,6 +578,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,6 +723,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,8 +747,8 @@ dependencies = [
 name = "muservice"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "axum",
+ "color-eyre",
  "config",
  "http",
  "hyper",
@@ -711,6 +793,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,6 +816,12 @@ dependencies = [
  "dlv-list",
  "hashbrown 0.12.3",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parking_lot"
@@ -1000,6 +1097,12 @@ dependencies = [
  "cfg-if",
  "ordered-multimap",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustls"
@@ -1473,6 +1576,16 @@ checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 tokio = {version="1.20.1", features=["full"]}
 sqlx = {version="0.6.1", features=["runtime-tokio-rustls", "postgres", "migrate"]}
 hyper = {version = "0.14.8", features=["client"]}
-anyhow = "1.0.61"
+color-eyre = "0.6.2"
 serde_json = "1.0.83"
 serde = {version = "1.0.143", features=["derive"]}
 config = {version = "0.13.2", features=["json"]}
@@ -28,3 +28,6 @@ axum = "0.5.15"
 tower-http = {version="0.3.4", features=["trace", "cors"]}
 tower = "0.4.13"
 http = "0.2.8"
+
+[profile.dev.package.backtrace]
+opt-level = 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     depends_on:
       - db
     environment:
-      - DATABASE_URL=postgres://postgres:admin@db/testdb?sslmode=disable
+      - DATABASE_URL=postgres://postgres:admin@db/tesatdb?sslmode=disable
     ports:
       - "3000:3000"
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     depends_on:
       - db
     environment:
-      - DATABASE_URL=postgres://postgres:admin@db/tesatdb?sslmode=disable
+      - DATABASE_URL=postgres://postgres:admin@db/testdb?sslmode=disable
     ports:
       - "3000:3000"
 volumes:

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, Context};
+use color_eyre::{Result, Help};
 use std::sync::Arc;
 
 use crate::db::DB;
@@ -10,7 +10,7 @@ pub struct AppState {
 
 impl AppState {
   pub async fn init() -> Result<Self> {
-    let db = DB::new().await.context("Unable to establish DB connection")?;
+    let db = DB::new().await.suggestion("Ensure that the Database URL environment variable is correct")?;
     Ok(AppState{db: Arc::new(db)})
   }
   pub fn db(&self) -> Arc<DB> {

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,5 +1,5 @@
 use sqlx::postgres::{PgPool, PgPoolOptions};
-use sqlx::{migrate};
+use sqlx::migrate;
 use color_eyre::{eyre::WrapErr, Result};
 use crate::settings::SETTINGS;
 use tracing::info;

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,6 +1,6 @@
 use sqlx::postgres::{PgPool, PgPoolOptions};
 use sqlx::{migrate};
-use anyhow::{Result, Context};
+use color_eyre::{eyre::WrapErr, Result};
 use crate::settings::SETTINGS;
 use tracing::info;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, Context};
+use color_eyre::{eyre::WrapErr, Result};
 use libmuservice::{router, server, app_state::AppState};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use libmuservice::settings::SETTINGS;
@@ -13,6 +13,7 @@ async fn main() -> Result<()> {
         ))
         .with(tracing_subscriber::fmt::layer())
         .init();
+    color_eyre::install()?;
 
     let app_state = AppState::init().await?;
     let router = router::build_router(app_state).await?;

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -7,7 +7,7 @@ use sqlx::{
 };
 use std::fmt::{Display, Formatter};
 use serde::{Deserialize, Serialize};
-use anyhow::{Result, Context};
+use color_eyre::{eyre::WrapErr, Result};
 
 #[derive(FromRow, Debug, Serialize, Deserialize)]
 pub struct User {
@@ -38,7 +38,7 @@ impl User {
   {
     let id = query_scalar::<_, i64>("insert into users(name, email) values($1, $2) returning id")
     .bind(self.name.clone()).bind(self.email.clone())
-    .fetch_one(ex).await.context("Unable to save")?;
+    .fetch_one(ex).await.context("Unable to save user")?;
     self.id = Some(id);
     Ok(())
   }

--- a/src/router.rs
+++ b/src/router.rs
@@ -28,7 +28,10 @@ async fn users_handler(req: Request<Body>) -> Result<Json<Vec<User>>, StatusCode
 async fn create_user_handler(Json(mut payload): Json<User>, Extension(state): Extension<AppState>) -> Result<Response, StatusCode> {
     payload.insert(&state.db().connection())
         .await
-        .map_err(|_|StatusCode::INTERNAL_SERVER_ERROR)?;
+        .map_err(|err| {
+            tracing::error!("{:?}", err);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
     Ok((
         StatusCode::CREATED,
         [("Content-Type", "application/json")]

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use color_eyre::Result;
 use axum::{
     body::Body,
     Extension,

--- a/src/router.rs
+++ b/src/router.rs
@@ -21,7 +21,10 @@ async fn users_handler(req: Request<Body>) -> Result<Json<Vec<User>>, StatusCode
     let state = req.extensions().get::<AppState>().ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
     let users = User::all(&state.db().connection())
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        .map_err(|err| {
+            tracing::error!("{:?}", err);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
     Ok(Json(users))
 }
 
@@ -39,7 +42,6 @@ async fn create_user_handler(Json(mut payload): Json<User>, Extension(state): Ex
 }
 
 pub async fn build_router(app_state: AppState) -> Result<Router<Body>> {
-    // let shared_state = app_state::AppState::init().await.context("error initializing state")?;
     let router = Router::new()
     .route("/", get(home_handler))
     .route("/users", get(users_handler))

--- a/src/server.rs
+++ b/src/server.rs
@@ -9,8 +9,9 @@ use crate::settings::SETTINGS;
 
 pub async fn serve(router: Router<Body>) -> Result<()>{
     let addr = SocketAddr::from_str(&format!("{}:{}", SETTINGS.host, SETTINGS.port))?;
+    let builder = Server::try_bind(&addr)?;
     info!("Server started listening on {}", addr);
-    match Server::bind(&addr)
+    match builder
         .serve(router.into_make_service())
         .await {
             Err(e) => Err(Report::new(e)),

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, Context, Error};
+use color_eyre::{Report, Result, eyre::Context};
 use axum::{Router, Server};
 use hyper::{Body};
 use std::net::SocketAddr;
@@ -13,7 +13,7 @@ pub async fn serve(router: Router<Body>) -> Result<()>{
     match Server::bind(&addr)
         .serve(router.into_make_service())
         .await {
-            Err(e) => Err(Error::msg(e.to_string())),
+            Err(e) => Err(Report::new(e)),
             Ok(rs) => Ok(rs)
     }.context("Unable to create router service")?;
     Ok(())

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,6 +1,6 @@
 use color_eyre::{Report, Result, eyre::Context};
 use axum::{Router, Server};
-use hyper::{Body};
+use hyper::Body;
 use std::net::SocketAddr;
 use std::str::FromStr;
 use tracing::log::info;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,6 +1,6 @@
 use std::env;
 use config::{File, Config, Environment, FileFormat};
-use anyhow::{Result, Context};
+use color_eyre::{Result, eyre::Context};
 use serde::Deserialize;
 use lazy_static::lazy_static;
 


### PR DESCRIPTION
Replaces anyhow with `color-eyre`. The features that `color-eyre` brings can be found through these two links: https://docs.rs/eyre/latest/eyre/ & https://docs.rs/color-eyre/latest/color_eyre/

`eyre` is a fork of `anyhow` and adds the type `eyre::Report`, which gives us more power for easy error handling. `color-eyre` adds colors to the error reporting and span traces. Note that no span traces are present in this PR. A separate PR will be added later that will bring in span traces if desired. 

This PR aims to gauge interest in `eyre`. `error-stack` is another crate that brings in a Report struct. However, `error-stack` is relatively new, and exists within the repo of a separate project. This means that the GitHub issues page contains issues for the parent project rather than for `error-stack`, so it is hard to find news on what's next for the crate and tips for usage. 

That being said, the major difference between `error-stack` and `eyre` is the usage paradigm. As `eyre` is forked from `anyhow`, it is simple to use, perfect for beginners. `error-stack` encourages swapping between error types for handling and is more verbose. It also allows wrapping errors with arbitrary data as opposed to `eyre`, where you are limited to string-like data unless you write a custom handler. `error-stack` is not compatible with `anyhow`, a compatibility layer between the two is a feature that may exist in the future.

I will likely write up an example for `error-stack` as a showcase in the near future for comparison.