### PR TITLE
Error stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,12 +23,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508b352bb5c066aac251f6daf6b36eccd03e8a88e8081cd44959ea277a3af9a8"
-
-[[package]]
 name = "async-trait"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,7 +668,6 @@ dependencies = [
 name = "muservice"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "axum",
  "config",
  "error-stack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,6 +276,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "error-stack"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5975af488b218348f3f183862f88e8699a91a809f0ee2658fcafaa6239d6759e"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,12 +677,14 @@ dependencies = [
  "anyhow",
  "axum",
  "config",
+ "error-stack",
  "http",
  "hyper",
  "lazy_static",
  "serde",
  "serde_json",
  "sqlx",
+ "thiserror",
  "tokio",
  "tower",
  "tower-http",
@@ -1002,6 +1013,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustls"
 version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,6 +1063,21 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/main.rs"
 tokio = {version="1.20.1", features=["full"]}
 sqlx = {version="0.6.1", features=["runtime-tokio-rustls", "postgres", "migrate"]}
 hyper = {version = "0.14.8", features=["client"]}
-anyhow = "1.0.61"
 serde_json = "1.0.83"
 serde = {version = "1.0.143", features=["derive"]}
 config = {version = "0.13.2", features=["json"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,5 @@ axum = "0.5.15"
 tower-http = {version="0.3.4", features=["trace", "cors"]}
 tower = "0.4.13"
 http = "0.2.8"
+error-stack = "0.1.1"
+thiserror = "1.0.32"

--- a/settings/default.json
+++ b/settings/default.json
@@ -1,5 +1,5 @@
 {
-  "host": "129.0.0.1",
+  "host": "127.0.0.1",
   "port": 3000,
   "database": {
     "url": "postgres:///testdb?sslmode=disable"

--- a/settings/default.json
+++ b/settings/default.json
@@ -1,5 +1,5 @@
 {
-  "host": "127.0.0.1",
+  "host": "129.0.0.1",
   "port": 3000,
   "database": {
     "url": "postgres:///testdb?sslmode=disable"

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1,16 +1,16 @@
-use anyhow::{Result, Context};
+use error_stack::Result;
 use std::sync::Arc;
 
-use crate::db::DB;
+use crate::db::{DB, DBError};
 
 #[derive(Clone)]
 pub struct AppState {
-  db: Arc<DB>,
+  db: Arc<DB>
 }
 
 impl AppState {
-  pub async fn init() -> Result<Self> {
-    let db = DB::new().await.context("Unable to establish DB connection")?;
+  pub async fn init() -> Result<Self, DBError> {
+    let db = DB::new().await?;
     Ok(AppState{db: Arc::new(db)})
   }
   pub fn db(&self) -> Arc<DB> {

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,8 +1,17 @@
 use sqlx::postgres::{PgPool, PgPoolOptions};
 use sqlx::{migrate};
-use anyhow::{Result, Context};
+use error_stack::{IntoReport, Result, ResultExt};
+use thiserror::Error;
 use crate::settings::SETTINGS;
 use tracing::info;
+
+#[derive(Error, Debug)]
+pub enum DBError {
+    #[error("Unable to run migrations!")]
+    MigrationError(#[from] sqlx::migrate::MigrateError),
+    #[error("Unable to connect!")]
+    ConnectionError(#[from] sqlx::Error)
+}
 
 pub struct DB {
   pool: PgPool
@@ -12,13 +21,19 @@ impl DB {
   pub fn connection(&self) -> PgPool {
     self.pool.clone()
   }
-  pub async fn new() -> Result<Self> {
+  pub async fn new() -> Result<Self, DBError> {
     let pool = PgPoolOptions::new()
       .max_connections(5)
       .connect(&SETTINGS.database.url)
-      .await.context("Unable to connect")?;
+      .await
+      .map_err(|err| err.into())
+      .report()
+      .attach_printable_lazy(|| format!("Unable to connect!"))?;
     let migrator = migrate!();
-    migrator.run(&pool).await.context("Unable to run migrations!")?;
+    migrator.run(&pool).await
+    .map_err(|err| err.into())
+    .report()
+    .attach_printable_lazy(|| format!("Unable to run migrations!"))?;
     info!("Connected to database: {}", SETTINGS.database.url);
     Ok(DB{pool})
   }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, Context};
+use error_stack::{IntoReport, Result, ResultExt};
 use libmuservice::{router, server, app_state::AppState};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use libmuservice::settings::SETTINGS;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+
 use error_stack::{IntoReport, Result, ResultExt};
 use libmuservice::{router, server, app_state::AppState};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -5,7 +7,7 @@ use libmuservice::settings::SETTINGS;
 
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), impl Error> {
     tracing_subscriber::registry()
         .with(tracing_subscriber::EnvFilter::new(
             std::env::var("RUST_LOG")
@@ -16,5 +18,5 @@ async fn main() -> Result<()> {
 
     let app_state = AppState::init().await?;
     let router = router::build_router(app_state).await?;
-    server::serve(router).await.context("Unable to serve")
+    server::serve(router).await.report().attach_printable_lazy(|| format!("Unable to serve!"))?
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,11 @@
-use std::error::Error;
-
-use error_stack::{IntoReport, Result, ResultExt};
-use libmuservice::{router, server, app_state::AppState};
+use error_stack::{ Result, ResultExt};
+use libmuservice::{router, server::{self, ServerError}, app_state::AppState};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use libmuservice::settings::SETTINGS;
 
 
 #[tokio::main]
-async fn main() -> Result<(), impl Error> {
+async fn main() -> Result<(), ServerError> {
     tracing_subscriber::registry()
         .with(tracing_subscriber::EnvFilter::new(
             std::env::var("RUST_LOG")
@@ -16,7 +14,8 @@ async fn main() -> Result<(), impl Error> {
         .with(tracing_subscriber::fmt::layer())
         .init();
 
-    let app_state = AppState::init().await?;
-    let router = router::build_router(app_state).await?;
-    server::serve(router).await.report().attach_printable_lazy(|| format!("Unable to serve!"))?
+    let app_state = AppState::init().await.change_context(ServerError::ServerError)?;
+    let router = router::build_router(app_state).await;
+    server::serve(router).await.attach_printable_lazy(|| format!("Unable to serve!"))?;
+    Ok(())
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use axum::{
     body::Body,
     Extension,
@@ -35,7 +34,7 @@ async fn create_user_handler(Json(mut payload): Json<User>, Extension(state): Ex
     ).into_response())
 }
 
-pub async fn build_router(app_state: AppState) -> Result<Router<Body>> {
+pub async fn build_router(app_state: AppState) -> Router<Body> {
     // let shared_state = app_state::AppState::init().await.context("error initializing state")?;
     let router = Router::new()
     .route("/", get(home_handler))
@@ -46,5 +45,5 @@ pub async fn build_router(app_state: AppState) -> Result<Router<Body>> {
             .layer(Extension(app_state))
             .layer(TraceLayer::new_for_http())
     );
-    Ok(router)
+    router
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,20 +1,29 @@
-use anyhow::{Result, Context, Error};
 use axum::{Router, Server};
+use error_stack::{Report, IntoReport, ResultExt, Result};
 use hyper::{Body};
+use thiserror::Error;
 use std::net::SocketAddr;
 use std::str::FromStr;
 use tracing::log::info;
 
 use crate::settings::SETTINGS;
 
-pub async fn serve(router: Router<Body>) -> Result<()>{
-    let addr = SocketAddr::from_str(&format!("{}:{}", SETTINGS.host, SETTINGS.port))?;
+#[derive(Error, Debug)]
+pub enum ServerError {
+    #[error("Server returned an error!")]
+    ServerError
+}
+
+pub async fn serve(router: Router<Body>) -> Result<(), ServerError>{
+    let addr = SocketAddr::from_str(&format!("{}:{}", SETTINGS.host, SETTINGS.port))
+        .report()
+        .change_context(ServerError::ServerError)?;
     info!("Server started listening on {}", addr);
-    match Server::bind(&addr)
-        .serve(router.into_make_service())
+    let builder = Server::try_bind(&addr).report().change_context(ServerError::ServerError)?;
+        match builder.serve(router.into_make_service())
         .await {
-            Err(e) => Err(Error::msg(e.to_string())),
+            Err(e) => Err(Report::new(e).change_context(ServerError::ServerError)), //Maybe hyper::Error?
             Ok(rs) => Ok(rs)
-    }.context("Unable to create router service")?;
+    }.attach_printable_lazy(|| "Unable to create router service!")?;
     Ok(())
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,6 +1,6 @@
 use std::env;
-use config::{File, Config, Environment, FileFormat};
-use anyhow::{Result, Context};
+use config::{File, Config, Environment, FileFormat, ConfigError};
+use error_stack::{IntoReport, Result, ResultExt};
 use serde::Deserialize;
 use lazy_static::lazy_static;
 
@@ -18,7 +18,7 @@ pub struct Settings {
 }
 
 impl Settings {
-    pub fn new() -> Result<Self> {
+    pub fn new() -> Result<Self, ConfigError> {
         let env = env::var("ENV").ok();
         let mut builder = Config::builder()
             .add_source(File::new("settings/default", FileFormat::Json))
@@ -30,7 +30,7 @@ impl Settings {
         };
 
         let config = builder.build()?;
-        config.try_deserialize().context("Failed to parse JSON into Settings struct.")
+        config.try_deserialize().report().attach_printable_lazy(|| "Failed to parse JSON into Settings struct.")
     }
 }
 

--- a/tests/muservice.rs
+++ b/tests/muservice.rs
@@ -14,7 +14,7 @@ async fn test_should_work() {
     tokio::spawn(async move {
         axum::Server::from_tcp(listener)
             .unwrap()
-            .serve(libmuservice::router::build_router(app_state).await.unwrap().into_make_service())
+            .serve(libmuservice::router::build_router(app_state).await.into_make_service())
             .await
             .unwrap();
     });
@@ -40,7 +40,7 @@ async fn test_should_work() {
 async fn test_create_user_handler(pool: PgPool) {
     let db = DB::new_with_pool(pool);
     let app_state = AppState::init_with_db(db);
-    let mut router = libmuservice::router::build_router(app_state).await.unwrap();
+    let mut router = libmuservice::router::build_router(app_state).await;
 
     let user = User { id: None, name: "userman".to_string(), email: "email@email.com".to_string() };
 
@@ -58,7 +58,7 @@ async fn test_create_user_handler(pool: PgPool) {
 async fn test_users_handler_empty(pool: PgPool) {
     let db = DB::new_with_pool(pool);
     let app_state = AppState::init_with_db(db);
-    let mut router = libmuservice::router::build_router(app_state).await.unwrap();
+    let mut router = libmuservice::router::build_router(app_state).await;
 
     let request = Request::builder()
         .uri("/users")
@@ -75,7 +75,7 @@ async fn test_users_handler_empty(pool: PgPool) {
 async fn test_users_handler_has_user(pool: PgPool) {
     let db = DB::new_with_pool(pool);
     let app_state = AppState::init_with_db(db);
-    let mut router = libmuservice::router::build_router(app_state).await.unwrap();
+    let mut router = libmuservice::router::build_router(app_state).await;
 
     let request = Request::builder()
         .uri("/users")


### PR DESCRIPTION
Still requires some cleanup and better usage of the crate. For example, the ServerError enum currently only has one variant. `thiserror` makes enums easier to use than non-enum errors when the source error type is unclear, so it was a temporary fix to make the example functional. This will be fixed in the near future. For now, it will show what the codebase would look like if this crate were used. 